### PR TITLE
Chess piece movement with mouse (no rules enforced, taking does not work)

### DIFF
--- a/OOAD Chess/Assets/Prefabs/BishopBlack.prefab
+++ b/OOAD Chess/Assets/Prefabs/BishopBlack.prefab
@@ -87,6 +87,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4109035688981828}
   - component: {fileID: 478546288578764063}
+  - component: {fileID: 666561377779179701}
   m_Layer: 0
   m_Name: BishopBlack
   m_TagString: Untagged
@@ -121,3 +122,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1f84235ef623dcf47be081bb248738c1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  xPosition: 0
+  yPosition: 0
+  whiteTeam: 0
+--- !u!122 &666561377779179701
+Halo:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1821828046532228}
+  m_Enabled: 0
+  m_Color:
+    serializedVersion: 2
+    rgba: 4278248703
+  m_Size: 0.45

--- a/OOAD Chess/Assets/Prefabs/BishopWhite.prefab
+++ b/OOAD Chess/Assets/Prefabs/BishopWhite.prefab
@@ -87,6 +87,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4156057879406840}
   - component: {fileID: 7794318794195333734}
+  - component: {fileID: 3215131803816555316}
   m_Layer: 0
   m_Name: BishopWhite
   m_TagString: Untagged
@@ -121,3 +122,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1f84235ef623dcf47be081bb248738c1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  xPosition: 0
+  yPosition: 0
+  whiteTeam: 0
+--- !u!122 &3215131803816555316
+Halo:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1877345029257820}
+  m_Enabled: 0
+  m_Color:
+    serializedVersion: 2
+    rgba: 4278248703
+  m_Size: 0.45

--- a/OOAD Chess/Assets/Prefabs/KingBlack.prefab
+++ b/OOAD Chess/Assets/Prefabs/KingBlack.prefab
@@ -87,6 +87,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4263857828403546}
   - component: {fileID: 114307939757638814}
+  - component: {fileID: 3146306546525050047}
   m_Layer: 0
   m_Name: KingBlack
   m_TagString: Untagged
@@ -121,3 +122,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4a6046336fc64544b43ba5edcb8022b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  xPosition: 0
+  yPosition: 0
+  whiteTeam: 0
+--- !u!122 &3146306546525050047
+Halo:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1953080492828278}
+  m_Enabled: 0
+  m_Color:
+    serializedVersion: 2
+    rgba: 4278248703
+  m_Size: 0.45

--- a/OOAD Chess/Assets/Prefabs/KingWhite.prefab
+++ b/OOAD Chess/Assets/Prefabs/KingWhite.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4007661963955966}
   - component: {fileID: 114362388283019998}
+  - component: {fileID: 3471247918271769205}
   m_Layer: 0
   m_Name: KingWhite
   m_TagString: Untagged
@@ -44,6 +45,21 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4a6046336fc64544b43ba5edcb8022b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  xPosition: 0
+  yPosition: 0
+  whiteTeam: 0
+--- !u!122 &3471247918271769205
+Halo:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1097184490271986}
+  m_Enabled: 0
+  m_Color:
+    serializedVersion: 2
+    rgba: 4278248703
+  m_Size: 0.45
 --- !u!1 &1704396138873048
 GameObject:
   m_ObjectHideFlags: 0

--- a/OOAD Chess/Assets/Prefabs/KnightBlack.prefab
+++ b/OOAD Chess/Assets/Prefabs/KnightBlack.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4389543563478918}
   - component: {fileID: 114267012793112186}
+  - component: {fileID: 8499459428471081046}
   m_Layer: 0
   m_Name: KnightBlack
   m_TagString: Untagged
@@ -44,6 +45,21 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d3d65a637f4216546ac395c876211ef3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  xPosition: 0
+  yPosition: 0
+  whiteTeam: 0
+--- !u!122 &8499459428471081046
+Halo:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1747904550817830}
+  m_Enabled: 0
+  m_Color:
+    serializedVersion: 2
+    rgba: 4278248703
+  m_Size: 0.45
 --- !u!1 &1755294381223424
 GameObject:
   m_ObjectHideFlags: 0

--- a/OOAD Chess/Assets/Prefabs/KnightWhite.prefab
+++ b/OOAD Chess/Assets/Prefabs/KnightWhite.prefab
@@ -87,6 +87,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4915500284866466}
   - component: {fileID: 7691840380265536454}
+  - component: {fileID: 1649102247842317543}
   m_Layer: 0
   m_Name: KnightWhite
   m_TagString: Untagged
@@ -121,3 +122,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d3d65a637f4216546ac395c876211ef3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  xPosition: 0
+  yPosition: 0
+  whiteTeam: 0
+--- !u!122 &1649102247842317543
+Halo:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1486526489832934}
+  m_Enabled: 0
+  m_Color:
+    serializedVersion: 2
+    rgba: 4278248703
+  m_Size: 0.45

--- a/OOAD Chess/Assets/Prefabs/PawnBlack.prefab
+++ b/OOAD Chess/Assets/Prefabs/PawnBlack.prefab
@@ -87,6 +87,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4165263511856026}
   - component: {fileID: 114797565397493790}
+  - component: {fileID: 7159799766975138103}
   m_Layer: 0
   m_Name: PawnBlack
   m_TagString: Untagged
@@ -121,3 +122,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a04aabe9c8ab46e4fa6aeaa602be5746, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  xPosition: 0
+  yPosition: 0
+  whiteTeam: 0
+--- !u!122 &7159799766975138103
+Halo:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1795645163035938}
+  m_Enabled: 0
+  m_Color:
+    serializedVersion: 2
+    rgba: 4278248703
+  m_Size: 0.45

--- a/OOAD Chess/Assets/Prefabs/PawnWhite.prefab
+++ b/OOAD Chess/Assets/Prefabs/PawnWhite.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4530104840285186}
   - component: {fileID: 2407200201383075764}
+  - component: {fileID: 3953916487831403366}
   m_Layer: 0
   m_Name: PawnWhite
   m_TagString: Untagged
@@ -44,6 +45,21 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a04aabe9c8ab46e4fa6aeaa602be5746, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  xPosition: 0
+  yPosition: 0
+  whiteTeam: 0
+--- !u!122 &3953916487831403366
+Halo:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1716508534991360}
+  m_Enabled: 0
+  m_Color:
+    serializedVersion: 2
+    rgba: 4278248703
+  m_Size: 0.45
 --- !u!1 &1796349291995868
 GameObject:
   m_ObjectHideFlags: 0

--- a/OOAD Chess/Assets/Prefabs/QueenBlack.prefab
+++ b/OOAD Chess/Assets/Prefabs/QueenBlack.prefab
@@ -87,6 +87,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4020851039157838}
   - component: {fileID: 608007341434150516}
+  - component: {fileID: 4438139508655670431}
   m_Layer: 0
   m_Name: QueenBlack
   m_TagString: Untagged
@@ -121,3 +122,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 450531bb2b6c3144bbb6dbe65d65c0a6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  xPosition: 0
+  yPosition: 0
+  whiteTeam: 0
+--- !u!122 &4438139508655670431
+Halo:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1749751664417286}
+  m_Enabled: 0
+  m_Color:
+    serializedVersion: 2
+    rgba: 4278248703
+  m_Size: 0.45

--- a/OOAD Chess/Assets/Prefabs/QueenWhite.prefab
+++ b/OOAD Chess/Assets/Prefabs/QueenWhite.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4662895362774314}
   - component: {fileID: 114014707872736814}
+  - component: {fileID: 8570511181020595046}
   m_Layer: 0
   m_Name: QueenWhite
   m_TagString: Untagged
@@ -44,6 +45,21 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 450531bb2b6c3144bbb6dbe65d65c0a6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  xPosition: 0
+  yPosition: 0
+  whiteTeam: 0
+--- !u!122 &8570511181020595046
+Halo:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1108025435085622}
+  m_Enabled: 0
+  m_Color:
+    serializedVersion: 2
+    rgba: 4278248703
+  m_Size: 0.45
 --- !u!1 &1929762684162052
 GameObject:
   m_ObjectHideFlags: 0

--- a/OOAD Chess/Assets/Prefabs/RookBlack.prefab
+++ b/OOAD Chess/Assets/Prefabs/RookBlack.prefab
@@ -87,6 +87,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4029907411764404}
   - component: {fileID: 5845626017122788215}
+  - component: {fileID: 4797168954006791995}
   m_Layer: 0
   m_Name: RookBlack
   m_TagString: Untagged
@@ -124,3 +125,15 @@ MonoBehaviour:
   xPosition: 0
   yPosition: 0
   whiteTeam: 0
+--- !u!122 &4797168954006791995
+Halo:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1218684493727980}
+  m_Enabled: 0
+  m_Color:
+    serializedVersion: 2
+    rgba: 4278248703
+  m_Size: 0.45

--- a/OOAD Chess/Assets/Prefabs/RookWhite.prefab
+++ b/OOAD Chess/Assets/Prefabs/RookWhite.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4546329341212354}
   - component: {fileID: 3073833274729298214}
+  - component: {fileID: 3111467086870125832}
   m_Layer: 0
   m_Name: RookWhite
   m_TagString: Untagged
@@ -44,6 +45,21 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 195771a478d5e514f9735de18228d6a2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  xPosition: 0
+  yPosition: 0
+  whiteTeam: 0
+--- !u!122 &3111467086870125832
+Halo:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1125735659761782}
+  m_Enabled: 0
+  m_Color:
+    serializedVersion: 2
+    rgba: 4278248703
+  m_Size: 0.45
 --- !u!1 &1905761233848512
 GameObject:
   m_ObjectHideFlags: 0

--- a/OOAD Chess/Assets/Scenes/MainScene.unity
+++ b/OOAD Chess/Assets/Scenes/MainScene.unity
@@ -3067,7 +3067,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f76c472690a96dc48929d7cb97ef3ed5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  selectedPiece: {fileID: 0}
   printBoard: 0
+  board: {fileID: 2109037608}
+  player1Turn: 0
 --- !u!114 &2109037613
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/OOAD Chess/Assets/Scripts/BoardLogic.cs
+++ b/OOAD Chess/Assets/Scripts/BoardLogic.cs
@@ -166,6 +166,7 @@ public class BoardLogic : MonoBehaviour
             if (selected != null)
             {
                 Debug.Log("User clicked on a " + selected.getType() + " at [" + selectionTileX + " " + selectionTileY + "]");
+                chessGame.SelectedPiece = selected;
             }
             else
             {

--- a/OOAD Chess/Assets/Scripts/BoardLogic.cs
+++ b/OOAD Chess/Assets/Scripts/BoardLogic.cs
@@ -11,6 +11,8 @@ public class BoardLogic : MonoBehaviour
     public GameObject positionTextObj;
     public TileHighlighter tileHighlightor;
     public ChessGame chessGame;
+    private const float TILEOFFSET = 0.5f;
+    private const float TILESIZE = 1.0f;
 
     /*
      * Store the selected file location in 2D coordinates
@@ -158,19 +160,39 @@ public class BoardLogic : MonoBehaviour
             //Debug.Log("Selected tile: [" + selectionTileX + " " + selectionTileY + "]");
         }
 
-        //If we're hitting the the chessplae & we click the left mouse button
-        if(Input.GetMouseButtonDown(0) && Physics.Raycast(cameraRay, out mouseHit, 50.0f, lm))
+        //When user clicks the left mouse button and the mouse is hitting the board
+        if(Input.GetMouseButtonDown(0))
         {
-            //If we clicked on a chessPiece at that location...
-            ChessPiece selected = chessGame.getChessPieceAt(selectionTileX, selectionTileY);
-            if (selected != null)
+            mouseSelection(selectionTileX, selectionTileY);
+        }
+    }
+
+    private void mouseSelection(int tileX, int tileY)
+    {
+        //Check if valid position
+        if (validBoardPosition(tileX, tileY)){
+            ChessPiece selected = chessGame.getChessPieceAt(tileX, tileY);
+            if(selected != null)
             {
-                Debug.Log("User clicked on a " + selected.getType() + " at [" + selectionTileX + " " + selectionTileY + "]");
+                //We set the currently selected chess piece
+                Debug.Log("Click on " + selected.getType() + " at [" + selectionTileX + " " + selectionTileY + "]");
                 chessGame.SelectedPiece = selected;
+
             }
             else
             {
-                Debug.Log("User clicked on [" + selectionTileX + " " + selectionTileY + "]");
+                //Move the chessPiece
+ 
+                //Make sure that there is a currently selected chessPiece in the ChessGame script
+                if(chessGame.SelectedPiece != null)
+                {
+                    chessGame.moveSelectedChessPiece(tileX, tileY);
+                }
+                else
+                {
+                    //clear the selection
+                    chessGame.SelectedPiece = null;
+                }
             }
         }
     }
@@ -179,9 +201,27 @@ public class BoardLogic : MonoBehaviour
     {
         bool result = false;
 
-        if ((x >= 0 && x <= 7) && (y >= 0 && x <= y))
+        if (x >= 0 && x <= 7 && y >= 0 && y <= 7)
             result = true;
 
         return result;
     }
+
+    public void changeChessPiecePositionInWorld(int newX, int newY, ChessPiece selection)
+    {
+        if(validBoardPosition(newX, newY))
+        {
+            selection.transform.position = GetTileCenter(newX, newY);
+        }
+    }
+
+    //Helper function that finds the center of a file given the lower left position
+    private Vector3 GetTileCenter(int x, int y)
+    {
+        Vector3 centerOfTile = Vector3.zero;
+        centerOfTile.x += (TILESIZE * x) + TILEOFFSET;
+        centerOfTile.z += (TILESIZE * y) + TILEOFFSET;
+        return centerOfTile;
+    }
+
 }

--- a/OOAD Chess/Assets/Scripts/BoardLogic.cs
+++ b/OOAD Chess/Assets/Scripts/BoardLogic.cs
@@ -172,11 +172,19 @@ public class BoardLogic : MonoBehaviour
         //Check if valid position
         if (validBoardPosition(tileX, tileY)){
             ChessPiece selected = chessGame.getChessPieceAt(tileX, tileY);
+
+            //Did the mouse select a tile that has another chess piece on it?
             if(selected != null)
             {
                 //We set the currently selected chess piece
                 Debug.Log("Click on " + selected.getType() + " at [" + selectionTileX + " " + selectionTileY + "]");
-                chessGame.SelectedPiece = selected;
+
+                //If we don't have a selected chess piece, we set is as selected in ChessGame script
+                if (chessGame.SelectedPiece == null)
+                    chessGame.setSelectedChessPieceScript(selected);
+                else
+                    //We will move the chess piece there... (future prep for taking...)
+                    chessGame.moveSelectedChessPiece(tileX, tileY);
 
             }
             else
@@ -186,6 +194,7 @@ public class BoardLogic : MonoBehaviour
                 //Make sure that there is a currently selected chessPiece in the ChessGame script
                 if(chessGame.SelectedPiece != null)
                 {
+                    Debug.Log("I moving chess piece to [ " + tileX + " " + tileY + "]" );
                     chessGame.moveSelectedChessPiece(tileX, tileY);
                 }
                 else

--- a/OOAD Chess/Assets/Scripts/ChessGame.cs
+++ b/OOAD Chess/Assets/Scripts/ChessGame.cs
@@ -10,11 +10,14 @@ public class ChessGame : MonoBehaviour
     private int pieceCount = 32;        //The total chess piece count
     private int currentPieceCount = 0;  //Actual chess piece count
     public bool printBoard = false;
+    public BoardLogic board;
+    public bool player1Turn;        //Player1 (white team) goes first
 
     // Start is called before the first frame update
     void Start()
     {
         selectedPiece = null;
+        player1Turn = true;
         printCurrentBoard();
     }
 
@@ -33,12 +36,14 @@ public class ChessGame : MonoBehaviour
     {
         get { return selectedPiece; }
         set
-        {
-            if (value != null)
-                selectedPiece = value;
-            else
-                Debug.LogError("selectedPiece == null");
+        {           
+            selectedPiece = value;            
         }
+    }
+
+    public void setSelectedChessPieceScript(ChessPiece selected)
+    {
+        selectedPiece = selected;
     }
 
     //Adds the chess piece "ChessPiece" script to the chessGameBoard 2D array
@@ -90,7 +95,58 @@ public class ChessGame : MonoBehaviour
     }
 
     public ChessPiece getChessPieceAt(int x, int y)
+    {       
+        return chessGameBoard[x, y];         
+    }
+
+    private void clearChessPieceAt(int x, int y)
     {
-        return chessGameBoard[x, y];
+        chessGameBoard[x, y] = null;
+    }
+
+    /*
+     * Pre-Condition: We already have a selected chessPiece
+     * Post-Condition: We move the chessPiece both in the 2D array and the graphical world
+     */
+    public void moveSelectedChessPiece(int newX, int newY)
+    {
+        //Check if we have a selected piece
+        if (SelectedPiece == null)
+        {
+            Debug.LogError("moveSelectedChessPiece was called, but selectedPiece is null!");
+            return;
+        }
+
+        //Check if the move is legal
+        if (SelectedPiece.legalMove(newX, newY))
+        {
+            changeChessPiecePositionIn2DArray(newX, newY);
+            board.changeChessPiecePositionInWorld(newX, newY, selectedPiece);
+
+            //Clear the selection
+            SelectedPiece = null;
+        }
+    }
+
+    //Switches the player turn boolean
+    private void switchPlayer()
+    {
+        player1Turn = (player1Turn) ? false : true;
+    }
+
+    private void changeChessPiecePositionIn2DArray(int newX, int newY)
+    {
+        int oldX, oldY;
+        oldX = SelectedPiece.XPosition;
+        oldY = SelectedPiece.YPosition;
+
+        //Clear position in 2D array
+        clearChessPieceAt(oldX, oldY);
+
+        //Update position in the script attached to chessPiece
+        selectedPiece.setNewPosition(newX, newY);
+
+        //Put selectedPiece in the new location in 2D array
+        chessGameBoard[newX, newY] = selectedPiece;
     }
 }

--- a/OOAD Chess/Assets/Scripts/ChessGame.cs
+++ b/OOAD Chess/Assets/Scripts/ChessGame.cs
@@ -6,6 +6,7 @@ public class ChessGame : MonoBehaviour
 {
     //Index goes from 0-7 & 0-7
     private ChessPiece[,] chessGameBoard = new ChessPiece[8, 8];
+    public ChessPiece selectedPiece;
     private int pieceCount = 32;        //The total chess piece count
     private int currentPieceCount = 0;  //Actual chess piece count
     public bool printBoard = false;
@@ -13,6 +14,7 @@ public class ChessGame : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
+        selectedPiece = null;
         printCurrentBoard();
     }
 
@@ -24,6 +26,18 @@ public class ChessGame : MonoBehaviour
         {
             printCurrentBoard();
             printBoard = false;
+        }
+    }
+
+    public ChessPiece SelectedPiece
+    {
+        get { return selectedPiece; }
+        set
+        {
+            if (value != null)
+                selectedPiece = value;
+            else
+                Debug.LogError("selectedPiece == null");
         }
     }
 

--- a/OOAD Chess/Assets/Scripts/ChessGame.cs
+++ b/OOAD Chess/Assets/Scripts/ChessGame.cs
@@ -44,13 +44,24 @@ public class ChessGame : MonoBehaviour
     public void setSelectedChessPieceScript(ChessPiece selected)
     {
         selectedPiece = selected;
+        //Enable the glow halo
+        Behaviour halo = (Behaviour)selected.gameObject.GetComponent("Halo");
+        halo.enabled = true;
+    }
+
+    public void deselectChessPiece()
+    {
+        //Disable the glow halo
+        Behaviour halo = (Behaviour)selectedPiece.gameObject.GetComponent("Halo");
+        halo.enabled = false;
+        selectedPiece = null;
     }
 
     //Adds the chess piece "ChessPiece" script to the chessGameBoard 2D array
     public void AddChessPiece(ChessPiece piece)
     {
-        int x = piece.XPosition;
-        int y = piece.YPosition;
+        int x = piece.xPosition;
+        int y = piece.yPosition;
 
         if (checkBounds(x, y) && (currentPieceCount < 32))
         {
@@ -101,6 +112,7 @@ public class ChessGame : MonoBehaviour
 
     private void clearChessPieceAt(int x, int y)
     {
+        Debug.Log("I am about to set [ " + x + " " + y + "]" + " to null in 2D array");
         chessGameBoard[x, y] = null;
     }
 
@@ -117,14 +129,14 @@ public class ChessGame : MonoBehaviour
             return;
         }
 
-        //Check if the move is legal
+        //Check if the move is legal - looking at the polymorphic definition of the legalMove() in each chess piece
         if (SelectedPiece.legalMove(newX, newY))
         {
             changeChessPiecePositionIn2DArray(newX, newY);
             board.changeChessPiecePositionInWorld(newX, newY, selectedPiece);
 
             //Clear the selection
-            SelectedPiece = null;
+            deselectChessPiece();
         }
     }
 
@@ -137,16 +149,18 @@ public class ChessGame : MonoBehaviour
     private void changeChessPiecePositionIn2DArray(int newX, int newY)
     {
         int oldX, oldY;
-        oldX = SelectedPiece.XPosition;
-        oldY = SelectedPiece.YPosition;
+        oldX = SelectedPiece.xPosition;
+        oldY = SelectedPiece.yPosition;
 
         //Clear position in 2D array
         clearChessPieceAt(oldX, oldY);
 
         //Update position in the script attached to chessPiece
+        Debug.Log("Updating chess piece location in CheePiece script to [ " + newX + " " + newY + "]");
         selectedPiece.setNewPosition(newX, newY);
 
         //Put selectedPiece in the new location in 2D array
         chessGameBoard[newX, newY] = selectedPiece;
+        printCurrentBoard();
     }
 }

--- a/OOAD Chess/Assets/Scripts/ChessPiece.cs
+++ b/OOAD Chess/Assets/Scripts/ChessPiece.cs
@@ -32,30 +32,11 @@ public abstract class ChessPiece : MonoBehaviour
         this.type = type;
     }
 
-    public int XPosition{
-        get { return xPosition; }
-        set{
-            if (value >= 0 && value <= 7)
-                xPosition = value;
-            else
-                Debug.Log("Incorrect xPosition value! - Refused to set!");
-        }
-    }
-
-    public int YPosition {
-        get { return yPosition; }
-        set {
-            if (value >= 0 && value <= 7)
-                xPosition = value;
-            else
-                Debug.Log("Incorrect yPosition value! - Refused to set!");
-        } 
-    }
-
     public void setNewPosition(int newX, int newY)
     {
-        XPosition = newX;
-        YPosition = newY;
+        xPosition = newX;
+        yPosition = newY;
+        Debug.Log("In Chess Piece, location is now [ " + xPosition + " " + yPosition + "]");
     }
 
     //This overrides the ToString method so it prints the symbol of the chess piece!

--- a/OOAD Chess/Assets/Scripts/ChessPiece.cs
+++ b/OOAD Chess/Assets/Scripts/ChessPiece.cs
@@ -84,5 +84,11 @@ public abstract class ChessPiece : MonoBehaviour
         retType += this.type;
         return retType;
     }
+
+    //Checks if the passed in coordinates constitute to a logal move
+    public virtual bool legalMove(int x, int y)
+    {
+        return true;
+    }
         
 }


### PR DESCRIPTION
I stated working on the pawn movement. Before I started doing that, I just made it so we can move any* of the chess pieces on the board. It synchronizes with our 2D array of base type ChessPiece class. I also added a "halo glow" effect when a chess piece is selected. Warning, illegal moves are* allowed. This is just a working version of moving the chess pieces. No rules are enforced and if you move a chess piece over another, it will mess it up (i made it possible to prep for piece taking). 

You can ignore all the ".prefab" files. It's because I added the Halo effect